### PR TITLE
fix installer path: use XDG base dir instead of Cargo home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y curl
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    echo '. $HOME/.cargo/env' >> $HOME/.bashrc
+    echo '. $HOME/.local/bin' >> $HOME/.bashrc
 
 WORKDIR /root/local/app
 


### PR DESCRIPTION
uvの環境変数のインストール先の変更

## 変更前
```bash
$ docker compose up --build
Compose now can delegate build to bake for better performances
Just set COMPOSE_BAKE=true
[+] Building 3.8s (11/11) FINISHED                                                                                docker:desktop-linux
 => [app internal] load build definition from Dockerfile                                                                          0.0s
 => => transferring dockerfile: 294B                                                                                              0.0s
 => [app internal] load metadata for docker.io/library/debian:bookworm-slim                                                       3.5s
 => [app auth] library/debian:pull token for registry-1.docker.io                                                                 0.0s
 => [app internal] load .dockerignore                                                                                             0.0s
 => => transferring context: 2B                                                                                                   0.0s
 => [app 1/6] FROM docker.io/library/debian:bookworm-slim@sha256:1209d8fd77def86ceb6663deef7956481cc6c14a25e1e64daec12c0ceffcc19  0.0s
 => [app internal] load build context                                                                                             0.0s
 => => transferring context: 828B                                                                                                 0.0s
 => CACHED [app 2/6] RUN apt-get update && apt-get install -y curl                                                                0.0s
 => CACHED [app 3/6] RUN curl -LsSf https://astral.sh/uv/install.sh | sh &&     echo '. $HOME/.cargo/env' >> $HOME/.bashrc        0.0s
 => CACHED [app 4/6] WORKDIR /root/local/app                                                                                      0.0s
 => CACHED [app 5/6] COPY ./src/app/ ./                                                                                           0.0s
 => ERROR [app 6/6] RUN . $HOME/.bashrc && uv sync                                                                                0.2s
------                                                                                                                                 
 > [app 6/6] RUN . $HOME/.bashrc && uv sync:
0.121 /bin/sh: 21: .: cannot open /root/.cargo/env: No such file
------
failed to solve: process "/bin/sh -c . $HOME/.bashrc && uv sync" did not complete successfully: exit code: 2
```

## 変更後
```
$ docker compose up --build
Compose now can delegate build to bake for better performances
Just set COMPOSE_BAKE=true
[+] Building 1.7s (13/13) FINISHED                                                                                docker:desktop-linux
 => [app internal] load build definition from Dockerfile                                                                          0.0s
 => => transferring dockerfile: 294B                                                                                              0.0s
 => [app internal] load metadata for docker.io/library/debian:bookworm-slim                                                       1.7s
 => [app auth] library/debian:pull token for registry-1.docker.io                                                                 0.0s
 => [app internal] load .dockerignore                                                                                             0.0s
 => => transferring context: 2B                                                                                                   0.0s
 => [app 1/6] FROM docker.io/library/debian:bookworm-slim@sha256:1209d8fd77def86ceb6663deef7956481cc6c14a25e1e64daec12c0ceffcc19  0.0s
 => [app internal] load build context                                                                                             0.0s
 => => transferring context: 828B                                                                                                 0.0s
 => CACHED [app 2/6] RUN apt-get update && apt-get install -y curl                                                                0.0s
 => CACHED [app 3/6] RUN curl -LsSf https://astral.sh/uv/install.sh | sh &&     echo '. $HOME/.local/bin' >> $HOME/.bashrc        0.0s
 => CACHED [app 4/6] WORKDIR /root/local/app                                                                                      0.0s
 => CACHED [app 5/6] COPY ./src/app/ ./                                                                                           0.0s
 => CACHED [app 6/6] RUN . $HOME/.bashrc && uv sync                                                                               0.0s
 => [app] exporting to image                                                                                                      0.0s
 => => exporting layers                                                                                                           0.0s
 => => writing image sha256:a34fe822a5ee0a241a1be7efac0e12ee77467025d1bebe3066eb459c154a8600                                      0.0s
 => => naming to docker.io/library/uv_on_docker_playground-app                                                                    0.0s
 => [app] resolving provenance for metadata file                                                                                  0.0s
[+] Running 2/2
 ✔ app                                      Built                                                                                 0.0s 
 ✔ Container uv_on_docker_playground-app-1  Created                                                                               0.1s 
Attaching to app-1
```

問題なくコンテナが起動した